### PR TITLE
Quote the defaultValueType when setting default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -257,6 +257,6 @@ export function getQueryToSetColumnDefault(tableName, columnName, defaultValue, 
   return `
     ALTER TABLE "${tableName}"
       ALTER COLUMN "${columnName}"
-        SET DEFAULT '${defaultValue}'::${defaultValueType}
+        SET DEFAULT '${defaultValue}'::"${defaultValueType}"
   `;
 }


### PR DESCRIPTION
The defaultValueType was unquoted, which resulted in an error `type "..." does not exist` when the enumType contained capitals.